### PR TITLE
Configure HTTP client timeouts

### DIFF
--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -1,9 +1,4 @@
-on:
-  push:
-    branches:
-      - main
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: push
 
 name: CodeSee Map
 

--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -1,4 +1,9 @@
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 name: CodeSee Map
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ wait-for:
     target: http://the-service:8080/health?reload=true
     interval: 5s
     timeout: 60s
+    http_client_timeout: 3s
   another-service:
     type: http
     target: https://another-one

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ wait-for:
     target: http://the-service:8080/health?reload=true
     interval: 5s
     timeout: 60s
-    http_client_timeout: 3s
+    http-client-timeout: 3s
   another-service:
     type: http
     target: https://another-one

--- a/cmd/wait-for/main.go
+++ b/cmd/wait-for/main.go
@@ -14,10 +14,12 @@ func main() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 
 	timeoutParam := "5s"
+	httpTimeoutParam := "1s"
 	configFile := ""
 	var quiet bool
 
 	flag.StringVar(&timeoutParam, "timeout", timeoutParam, "time to wait for services to become available")
+	flag.StringVar(&httpTimeoutParam, "http_timeout", httpTimeoutParam, "timeout for requests made by a http client")
 	flag.StringVar(&configFile, "config", "", "configuration file to use")
 	flag.BoolVar(&quiet, "quiet", false, "reduce output to the minimum")
 	flag.Parse()
@@ -32,7 +34,7 @@ func main() {
 		logger = waitfor.NullLogger
 	}
 
-	config, err := waitfor.OpenConfig(configFile, timeoutParam, fs)
+	config, err := waitfor.OpenConfig(configFile, timeoutParam, httpTimeoutParam, fs)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%v", err)
 		os.Exit(1)

--- a/config.go
+++ b/config.go
@@ -24,14 +24,14 @@ type TargetConfig struct {
 	// Timeout is the timeout to use for this specific target if it is different to DefaultTimeout
 	Timeout time.Duration
 	// HTTPClientTimeout is the timeout for requests made by a http client
-	HTTPClientTimeout time.Duration `yaml:"http_client_timeout"`
+	HTTPClientTimeout time.Duration `yaml:"http-client-timeout"`
 }
 
 // Config represents all of the config that can be defined in a config file
 type Config struct {
 	DefaultTimeout           time.Duration `yaml:"default-timeout"`
 	Targets                  map[string]TargetConfig
-	DefaultHTTPClientTimeout time.Duration `yaml:"default_http_client_timeout"`
+	DefaultHTTPClientTimeout time.Duration `yaml:"default-http-client-timeout"`
 }
 
 // NewConfig creates an empty Config
@@ -57,16 +57,14 @@ func NewConfigFromFile(r io.Reader) (*Config, error) {
 		config.DefaultHTTPClientTimeout = DefaultHTTPClientTimeout
 	}
 	for t := range config.Targets {
+		target := config.Targets[t]
 		if config.Targets[t].Timeout == 0 {
-			target := config.Targets[t]
 			target.Timeout = config.DefaultTimeout
-			config.Targets[t] = target
 		}
 		if config.Targets[t].HTTPClientTimeout == 0 {
-			target := config.Targets[t]
 			target.HTTPClientTimeout = config.DefaultHTTPClientTimeout
-			config.Targets[t] = target
 		}
+		config.Targets[t] = target
 	}
 	return &config, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -40,7 +40,7 @@ func TestConfig_incorrectHTTPTimeoutDurationFails(t *testing.T) {
     type: http
     target: http://localhost/health
     timeout: 10s
-    http_client_timeout: not parsable`))
+    http-client-timeout: not parsable`))
 
 	assert.Error(t, err)
 	assert.Nil(t, config)
@@ -60,7 +60,7 @@ targets:
 
 func TestConfig_settingDefaultHTTPTimeoutWorks(t *testing.T) {
 	config, err := NewConfigFromFile(strings.NewReader(`
-default_http_client_timeout: 18s
+default-http-client-timeout: 18s
 targets:
   http-connection:
     type: http
@@ -129,7 +129,7 @@ func defaultConfigYaml() string {
     type: http
     target: http://localhost/health
     timeout: 10s
-    http_client_timeout: 5s
+    http-client-timeout: 5s
   tcp-connection:
     type: tcp
     target: localhost:80


### PR DESCRIPTION
# Description

This PR allows configuring HTTP client timeout in the config file for each target and as a command line flag.

Fixes # ([7](https://github.com/dnnrly/wait-for/issues/7))

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Running existing tests
- [x] Created new tests

# Checklist:

- [x] My code has been linted (`make lint`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch to include the latest changes from `master`
