### PR TITLE
Argument for Expected response code Fixes (9) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ to become available before continuing - or timeout and exit with an error.
 
 At the moment, you can wait for a few different kinds of thing. They are:
 
-* HTTP or HTTPS success response
+* HTTP or HTTPS success response or any expected response following regular expressions
 * TCP or GRPC connection
 * DNS IP resolve address change
 
@@ -54,6 +54,12 @@ Feel free to choose from any of the other releases though.
 ```shell script
 $ wait-for http://your-service-here:8080/health https://another-service/
 ``` 
+
+### Waiting for HTTP services with expected response status
+
+```shell script
+$ wait-for -regex=[0-2]{3} http://your-service-here:8080/health 
+```  
 
 ### Waiting for gRPC services
 
@@ -137,17 +143,6 @@ command.
 ```shell script
 $ make build
 ```
-### Running the tool
-
-To run the tool on Linux / Mac
-```shell script
-$ ./cmd/wait-for
-```
-To run the tool on Windows
-```shell script
-$ wait-for.exe 
-```
-
 
 ### Unit tests
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $ make build
 
 To run the tool on Linux / Mac
 ```shell script
-$ .\wait-for 
+$ ./cmd/wait-for
 ```
 To run the tool on Windows
 ```shell script

--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ command.
 ```shell script
 $ make build
 ```
+### Running the tool
+
+To run the tool on Linux / Mac
+```shell script
+$ .\wait-for 
+```
+To run the tool on Windows
+```shell script
+$ wait-for.exe 
+```
+
 
 ### Unit tests
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ wait-for http://your-service-here:8080/health https://another-service/
 ### Waiting for HTTP services with expected response status
 
 ```shell script
-$ wait-for -regex=[0-2]{3} http://your-service-here:8080/health 
+$ wait-for -status=[0-2]{3} http://your-service-here:8080/health 
 ```  
 
 ### Waiting for gRPC services

--- a/cmd/wait-for/main.go
+++ b/cmd/wait-for/main.go
@@ -18,13 +18,13 @@ func main() {
 	httpTimeoutParam := "1s"
 	configFile := ""
 	var quiet bool
-	regexStatus := ""
+	statusPatternParam := "200"
 
 	flag.StringVar(&timeoutParam, "timeout", timeoutParam, "time to wait for services to become available")
 	flag.StringVar(&httpTimeoutParam, "http_timeout", httpTimeoutParam, "timeout for requests made by a http client")
 	flag.StringVar(&configFile, "config", "", "configuration file to use")
 	flag.BoolVar(&quiet, "quiet", false, "reduce output to the minimum")
-	flag.StringVar(&regexStatus, "regex", "", "Use regex to match the expected result in HTTP status codes")
+	flag.StringVar(&statusPatternParam, "status", statusPatternParam, "A golang regex that represents the desired HTTP status response code")
 	flag.Parse()
 
 	fs := afero.NewOsFs()
@@ -37,7 +37,7 @@ func main() {
 		logger = waitfor.NullLogger
 	}
 
-	config, err := waitfor.OpenConfig(configFile, timeoutParam, httpTimeoutParam, fs, regexStatus)
+	config, err := waitfor.OpenConfig(configFile, timeoutParam, httpTimeoutParam, fs, statusPatternParam)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%v", err)
 		os.Exit(1)

--- a/cmd/wait-for/main.go
+++ b/cmd/wait-for/main.go
@@ -18,11 +18,13 @@ func main() {
 	httpTimeoutParam := "1s"
 	configFile := ""
 	var quiet bool
+	regexStatus := ""
 
 	flag.StringVar(&timeoutParam, "timeout", timeoutParam, "time to wait for services to become available")
 	flag.StringVar(&httpTimeoutParam, "http_timeout", httpTimeoutParam, "timeout for requests made by a http client")
 	flag.StringVar(&configFile, "config", "", "configuration file to use")
 	flag.BoolVar(&quiet, "quiet", false, "reduce output to the minimum")
+	flag.StringVar(&regexStatus, "regex", "", "Use regex to match the expected result in HTTP status codes")
 	flag.Parse()
 
 	fs := afero.NewOsFs()
@@ -35,7 +37,7 @@ func main() {
 		logger = waitfor.NullLogger
 	}
 
-	config, err := waitfor.OpenConfig(configFile, timeoutParam, httpTimeoutParam, fs)
+	config, err := waitfor.OpenConfig(configFile, timeoutParam, httpTimeoutParam, fs, regexStatus)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%v", err)
 		os.Exit(1)

--- a/cmd/wait-for/main.go
+++ b/cmd/wait-for/main.go
@@ -18,7 +18,7 @@ func main() {
 	httpTimeoutParam := "1s"
 	configFile := ""
 	var quiet bool
-	statusPatternParam := "200"
+	statusPatternParam := "^2..$"
 
 	flag.StringVar(&timeoutParam, "timeout", timeoutParam, "time to wait for services to become available")
 	flag.StringVar(&httpTimeoutParam, "http_timeout", httpTimeoutParam, "timeout for requests made by a http client")
@@ -37,7 +37,7 @@ func main() {
 		logger = waitfor.NullLogger
 	}
 
-	config, err := waitfor.OpenConfig(configFile, timeoutParam, httpTimeoutParam, fs, statusPatternParam)
+	config, err := waitfor.OpenConfig(configFile, timeoutParam, httpTimeoutParam, statusPatternParam, fs)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%v", err)
 		os.Exit(1)

--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ const DefaultTimeout = time.Second * 5
 const DefaultHTTPClientTimeout = time.Second
 
 // DefaultStatusPattern is a default value for the Regex pattern to match in the expected result
-const DefaultStatusPattern = "200"
+const DefaultStatusPattern = "^2..$"
 
 // TargetConfig is the configuration of a single target
 type TargetConfig struct {

--- a/config.go
+++ b/config.go
@@ -15,6 +15,9 @@ const DefaultTimeout = time.Second * 5
 // DefaultHTTPClientTimeout a default value for a time limit for requests made by http client
 const DefaultHTTPClientTimeout = time.Second
 
+// DefaultRegexStatus a default value for the Regex pattern to match in the expected result
+const DefaultRegexStatus = ""
+
 // TargetConfig is the configuration of a single target
 type TargetConfig struct {
 	// Type is the kind of target being described
@@ -25,13 +28,16 @@ type TargetConfig struct {
 	Timeout time.Duration
 	// HTTPClientTimeout is the timeout for requests made by a http client
 	HTTPClientTimeout time.Duration `yaml:"http-client-timeout"`
+	// Regex is the regular expression pattern to match in the expected http status code result
+	RegexStatus string `yaml:"http-client-regex"`
 }
 
-// Config represents all of the config that can be defined in a config file
+// Config represents all the config that can be defined in a config file
 type Config struct {
 	DefaultTimeout           time.Duration `yaml:"default-timeout"`
 	Targets                  map[string]TargetConfig
 	DefaultHTTPClientTimeout time.Duration `yaml:"default-http-client-timeout"`
+	DefaultRegexStatus       string        `yaml:"default-http-client-regex"`
 }
 
 // NewConfig creates an empty Config
@@ -40,6 +46,7 @@ func NewConfig() *Config {
 		DefaultTimeout:           DefaultTimeout,
 		Targets:                  map[string]TargetConfig{},
 		DefaultHTTPClientTimeout: DefaultHTTPClientTimeout,
+		DefaultRegexStatus:       DefaultRegexStatus,
 	}
 }
 
@@ -56,6 +63,9 @@ func NewConfigFromFile(r io.Reader) (*Config, error) {
 	if config.DefaultHTTPClientTimeout == 0 {
 		config.DefaultHTTPClientTimeout = DefaultHTTPClientTimeout
 	}
+	if config.DefaultRegexStatus == "" {
+		config.DefaultRegexStatus = DefaultRegexStatus
+	}
 	for t := range config.Targets {
 		target := config.Targets[t]
 		if config.Targets[t].Timeout == 0 {
@@ -63,6 +73,9 @@ func NewConfigFromFile(r io.Reader) (*Config, error) {
 		}
 		if config.Targets[t].HTTPClientTimeout == 0 {
 			target.HTTPClientTimeout = config.DefaultHTTPClientTimeout
+		}
+		if config.Targets[t].RegexStatus == "" {
+			target.RegexStatus = config.DefaultRegexStatus
 		}
 		config.Targets[t] = target
 	}
@@ -92,6 +105,7 @@ func (c *Config) AddFromString(t string) error {
 			Type:              "http",
 			Timeout:           c.DefaultTimeout,
 			HTTPClientTimeout: c.DefaultHTTPClientTimeout,
+			RegexStatus:       c.DefaultRegexStatus,
 		}
 		return nil
 	}
@@ -105,7 +119,7 @@ func (c *Config) AddFromString(t string) error {
 		return nil
 	}
 
-	return errors.New("unable to understand target " + t)
+	return errors.New("unable to understand target  " + t)
 }
 
 func (c *Config) Filter(targets []string) *Config {

--- a/config.go
+++ b/config.go
@@ -15,8 +15,8 @@ const DefaultTimeout = time.Second * 5
 // DefaultHTTPClientTimeout a default value for a time limit for requests made by http client
 const DefaultHTTPClientTimeout = time.Second
 
-// DefaultRegexStatus a default value for the Regex pattern to match in the expected result
-const DefaultRegexStatus = ""
+// DefaultStatusPattern is a default value for the Regex pattern to match in the expected result
+const DefaultStatusPattern = "200"
 
 // TargetConfig is the configuration of a single target
 type TargetConfig struct {
@@ -29,7 +29,7 @@ type TargetConfig struct {
 	// HTTPClientTimeout is the timeout for requests made by a http client
 	HTTPClientTimeout time.Duration `yaml:"http-client-timeout"`
 	// Regex is the regular expression pattern to match in the expected http status code result
-	RegexStatus string `yaml:"http-client-regex"`
+	StatusPattern string `yaml:"http-client-status-pattern"`
 }
 
 // Config represents all the config that can be defined in a config file
@@ -37,7 +37,7 @@ type Config struct {
 	DefaultTimeout           time.Duration `yaml:"default-timeout"`
 	Targets                  map[string]TargetConfig
 	DefaultHTTPClientTimeout time.Duration `yaml:"default-http-client-timeout"`
-	DefaultRegexStatus       string        `yaml:"default-http-client-regex"`
+	DefaultStatusPattern     string        `yaml:"default-http-client-status-pattern"`
 }
 
 // NewConfig creates an empty Config
@@ -46,7 +46,7 @@ func NewConfig() *Config {
 		DefaultTimeout:           DefaultTimeout,
 		Targets:                  map[string]TargetConfig{},
 		DefaultHTTPClientTimeout: DefaultHTTPClientTimeout,
-		DefaultRegexStatus:       DefaultRegexStatus,
+		DefaultStatusPattern:     DefaultStatusPattern,
 	}
 }
 
@@ -63,8 +63,8 @@ func NewConfigFromFile(r io.Reader) (*Config, error) {
 	if config.DefaultHTTPClientTimeout == 0 {
 		config.DefaultHTTPClientTimeout = DefaultHTTPClientTimeout
 	}
-	if config.DefaultRegexStatus == "" {
-		config.DefaultRegexStatus = DefaultRegexStatus
+	if config.DefaultStatusPattern == "" {
+		config.DefaultStatusPattern = DefaultStatusPattern
 	}
 	for t := range config.Targets {
 		target := config.Targets[t]
@@ -74,8 +74,8 @@ func NewConfigFromFile(r io.Reader) (*Config, error) {
 		if config.Targets[t].HTTPClientTimeout == 0 {
 			target.HTTPClientTimeout = config.DefaultHTTPClientTimeout
 		}
-		if config.Targets[t].RegexStatus == "" {
-			target.RegexStatus = config.DefaultRegexStatus
+		if config.Targets[t].StatusPattern == "" {
+			target.StatusPattern = config.DefaultStatusPattern
 		}
 		config.Targets[t] = target
 	}
@@ -105,7 +105,7 @@ func (c *Config) AddFromString(t string) error {
 			Type:              "http",
 			Timeout:           c.DefaultTimeout,
 			HTTPClientTimeout: c.DefaultHTTPClientTimeout,
-			RegexStatus:       c.DefaultRegexStatus,
+			StatusPattern:     c.DefaultStatusPattern,
 		}
 		return nil
 	}
@@ -119,7 +119,7 @@ func (c *Config) AddFromString(t string) error {
 		return nil
 	}
 
-	return errors.New("unable to understand target  " + t)
+	return errors.New("unable to understand target " + t)
 }
 
 func (c *Config) Filter(targets []string) *Config {

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -235,6 +235,10 @@ func (s *stepsData) listeningServerWaitsThenResponds(port int, duration string, 
 	return nil
 }
 
+func iRunWaitforWithParametersAndWithStatusArgument(arg1, arg2 string) error {
+	return godog.ErrPending
+}
+
 func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 	ctx.BeforeSuite(func() {
 	})
@@ -261,12 +265,14 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 			fmt.Printf("Output is:\n%s\n", data.output)
 		}
 	})
+
 	ctx.Step(`^I run wait-for with parameters "([^"]*)"$`, data.iRunWaitforWithParameters)
 	ctx.Step(`^wait-for exits without error$`, data.waitforExitsWithoutError)
 	ctx.Step(`^wait-for exits with an error$`, data.waitforExitsWithAnError)
 	ctx.Step(`^the output contains "([^"]*)"$`, data.theOutputContains)
 	ctx.Step(`^the output does not contain "([^"]*)"$`, data.theOutputDoesNotContain)
 	ctx.Step(`^I can see that an HTTP request was made for "([^"]*)"$`, data.iCanSeeThatAnHTTPRequestWasMadeFor)
+	ctx.Step(`^I run wait-for with parameters "([^"]*)" and with status argument "([^"]*)"$`, iRunWaitforWithParametersAndWithStatusArgument)
 	ctx.Step(`^I have an HTTP server running on port (\d+) that responds with (\d+)$`, data.iHaveAnHTTPServerOnPortWithStatus)
 	ctx.Step(`^the time taken is more than "([^"]*)"`, data.theTimeTakenIsMoreThan)
 	ctx.Step(`^the time taken is less than "([^"]*)"$`, data.theTimeTakenIsLessThan)

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -235,10 +235,6 @@ func (s *stepsData) listeningServerWaitsThenResponds(port int, duration string, 
 	return nil
 }
 
-func iRunWaitforWithParametersAndWithStatusArgument(arg1, arg2 string) error {
-	return godog.ErrPending
-}
-
 func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 	ctx.BeforeSuite(func() {
 	})
@@ -265,14 +261,12 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 			fmt.Printf("Output is:\n%s\n", data.output)
 		}
 	})
-
 	ctx.Step(`^I run wait-for with parameters "([^"]*)"$`, data.iRunWaitforWithParameters)
 	ctx.Step(`^wait-for exits without error$`, data.waitforExitsWithoutError)
 	ctx.Step(`^wait-for exits with an error$`, data.waitforExitsWithAnError)
 	ctx.Step(`^the output contains "([^"]*)"$`, data.theOutputContains)
 	ctx.Step(`^the output does not contain "([^"]*)"$`, data.theOutputDoesNotContain)
 	ctx.Step(`^I can see that an HTTP request was made for "([^"]*)"$`, data.iCanSeeThatAnHTTPRequestWasMadeFor)
-	ctx.Step(`^I run wait-for with parameters "([^"]*)" and with status argument "([^"]*)"$`, iRunWaitforWithParametersAndWithStatusArgument)
 	ctx.Step(`^I have an HTTP server running on port (\d+) that responds with (\d+)$`, data.iHaveAnHTTPServerOnPortWithStatus)
 	ctx.Step(`^the time taken is more than "([^"]*)"`, data.theTimeTakenIsMoreThan)
 	ctx.Step(`^the time taken is less than "([^"]*)"$`, data.theTimeTakenIsLessThan)

--- a/test/features/cli.feature
+++ b/test/features/cli.feature
@@ -14,11 +14,20 @@ Feature: Configuration from CLI
     And the output contains "finished waiting for http://localhost/health"
     And wait-for exits without error
 
+  Scenario: Waits on a HTTP service with a custom status pattern
+    Given I have an HTTP server running on port 80 that responds with 404
+    Given I have an HTTP server running on port 8080 that responds with 4040
+    When I run wait-for with parameters "http://localhost/health" and with status argument "404"
+    Then I can see that an HTTP request was made for "localhost GET /health"
+    And the output contains "started waiting for http://localhost/health"
+    And the output contains "finished waiting for http://localhost/health"
+    And wait-for exits without error
+
   Scenario: Waits on a TCP connection
     Given I have an HTTP server running on port 80 that waits "10s" then responds with 200
     Given I have an HTTP server running on port 8080 that responds with 200
     When I run wait-for with parameters "tcp:localhost:80"
-    Then I can see a connection event "127.0.0.1:80 new"
+    Then I can see a connection event "127.0.0.1:80 new"or "[::1]:80 new"
     And the output contains "started waiting for tcp:localhost:80"
     And the output contains "finished waiting for tcp:localhost:80"
     And wait-for exits without error

--- a/test/features/cli.feature
+++ b/test/features/cli.feature
@@ -76,6 +76,28 @@ Feature: Configuration from CLI
     And the time taken is less than "5s"
     And the output contains "timed out waiting for http://non-existent/health"
 
+  Scenario: Status is configurable
+    Given I have an HTTP server running on port 80 that responds with 400
+    When I run wait-for with parameters "-status 400 http://localhost/health"
+    Then I can see that an HTTP request was made for "localhost GET /health"
+    And the output contains "finished waiting for http://localhost/health"
+    And wait-for exits without error
+
+  Scenario: Fails when status is not a valid regex
+    Given I have an HTTP server running on port 80 that responds with 200
+    When I run wait-for with parameters "-status [4-0]{3} http://localhost/health"
+    Then I can see that an HTTP request was made for "localhost GET /health"
+    And the output contains " error while waiting for http://localhost/health:  invalid Regular Expression"
+    And wait-for exits with an error
+
+  Scenario: Fails when status doesn't match response
+    Given I have an HTTP server running on port 80 that responds with 200
+    When I run wait-for with parameters "-status 500 http://localhost/health"
+    Then I can see that an HTTP request was made for "localhost GET /health"
+    And the output contains " error while waiting for http://localhost/health:  200 status Code and 500 regex didn't match"
+    And wait-for exits with an error
+
+
   Scenario: Quiet option removes output when successful
     Given I have an HTTP server running on port 80 that responds with 500 for "3s" then responds with 200
     When I run wait-for with parameters "-quiet http://localhost/health"

--- a/test/features/cli.feature
+++ b/test/features/cli.feature
@@ -14,20 +14,11 @@ Feature: Configuration from CLI
     And the output contains "finished waiting for http://localhost/health"
     And wait-for exits without error
 
-  Scenario: Waits on a HTTP service with a custom status pattern
-    Given I have an HTTP server running on port 80 that responds with 404
-    Given I have an HTTP server running on port 8080 that responds with 4040
-    When I run wait-for with parameters "http://localhost/health" and with status argument "404"
-    Then I can see that an HTTP request was made for "localhost GET /health"
-    And the output contains "started waiting for http://localhost/health"
-    And the output contains "finished waiting for http://localhost/health"
-    And wait-for exits without error
-
   Scenario: Waits on a TCP connection
     Given I have an HTTP server running on port 80 that waits "10s" then responds with 200
     Given I have an HTTP server running on port 8080 that responds with 200
     When I run wait-for with parameters "tcp:localhost:80"
-    Then I can see a connection event "127.0.0.1:80 new"or "[::1]:80 new"
+    Then I can see a connection event "127.0.0.1:80 new"
     And the output contains "started waiting for tcp:localhost:80"
     And the output contains "finished waiting for tcp:localhost:80"
     And wait-for exits without error

--- a/waitfor.go
+++ b/waitfor.go
@@ -60,7 +60,7 @@ func WaitOn(config *Config, logger Logger, targets []string, waiters map[string]
 	return nil
 }
 
-func OpenConfig(configFile, defaultTimeout, defaultHTTPTimeout string, fs afero.Fs, defaultStatusPattern string) (*Config, error) {
+func OpenConfig(configFile, defaultTimeout, defaultHTTPTimeout, defaultStatusPattern string, fs afero.Fs) (*Config, error) {
 	var config *Config
 	if configFile == "" {
 		config = NewConfig()

--- a/waitfor.go
+++ b/waitfor.go
@@ -60,7 +60,7 @@ func WaitOn(config *Config, logger Logger, targets []string, waiters map[string]
 	return nil
 }
 
-func OpenConfig(configFile, defaultTimeout, defaultHTTPTimeout string, fs afero.Fs, defaultRegexPattern string) (*Config, error) {
+func OpenConfig(configFile, defaultTimeout, defaultHTTPTimeout string, fs afero.Fs, defaultStatusPattern string) (*Config, error) {
 	var config *Config
 	if configFile == "" {
 		config = NewConfig()
@@ -86,7 +86,7 @@ func OpenConfig(configFile, defaultTimeout, defaultHTTPTimeout string, fs afero.
 		return nil, fmt.Errorf("unable to parse http timeout: %v", err)
 	}
 	config.DefaultHTTPClientTimeout = httpTimeout
-	config.DefaultRegexStatus = defaultRegexPattern
+	config.DefaultStatusPattern = defaultStatusPattern
 	return config, nil
 }
 
@@ -156,9 +156,9 @@ func HTTPWaiter(name string, target *TargetConfig) error {
 	if err != nil {
 		return fmt.Errorf("could not connect to %s: %v", name, err)
 	}
-	if target.RegexStatus != "" {
+	if target.StatusPattern != "200" {
 		// simplifies safe initialization for holding compiled regular expressions.
-		pattern, err := regexp.Compile(target.RegexStatus)
+		pattern, err := regexp.Compile(target.StatusPattern)
 		if err != nil {
 			return fmt.Errorf("invalid Regular Expression %v", err)
 		}

--- a/waitfor.go
+++ b/waitfor.go
@@ -182,7 +182,7 @@ func GRPCWaiter(name string, target *TargetConfig) error {
 
 // checkStatus checks if the given HTTP status code matches the pattern provided in the target configuration.
 func checkStatus(targetPattern string, code int) error {
-	if targetPattern != "200" {
+	if targetPattern != "^2..$" {
 		// Safely compile and initialize  the regular expression pattern and verify if it's valid
 		pattern, err := regexp.Compile(targetPattern)
 		if err != nil {
@@ -191,25 +191,8 @@ func checkStatus(targetPattern string, code int) error {
 		if !pattern.MatchString(strconv.Itoa(code)) {
 			return fmt.Errorf("%d status Code and %s regex didn't match", code, pattern.String())
 		}
-		// if the target is set to default "200", check if the status code is a successful status code
-	} else {
-		if !isSuccess(code) {
-			return fmt.Errorf("got %d ", code)
-		}
 	}
 	return nil
-}
-
-func isSuccess(code int) bool {
-	if code < 200 {
-		return false
-	}
-
-	if code >= 300 {
-		return false
-	}
-
-	return true
 }
 
 type DNSLookup func(host string) ([]net.IP, error)

--- a/waitfor.go
+++ b/waitfor.go
@@ -148,7 +148,6 @@ func TCPWaiter(name string, target *TargetConfig) error {
 }
 
 func HTTPWaiter(name string, target *TargetConfig) error {
-
 	client := &http.Client{
 		Timeout: target.HTTPClientTimeout,
 	}
@@ -158,7 +157,11 @@ func HTTPWaiter(name string, target *TargetConfig) error {
 		return fmt.Errorf("could not connect to %s: %v", name, err)
 	}
 	if target.RegexStatus != "" {
-		pattern := regexp.MustCompile(target.RegexStatus)
+		// simplifies safe initialization for holding compiled regular expressions.
+		pattern, err := regexp.Compile(target.RegexStatus)
+		if err != nil {
+			return fmt.Errorf("invalid Regular Expression %v", err)
+		}
 		// Check if the given pattern matches the status code
 		if !pattern.MatchString(strconv.Itoa(resp.StatusCode)) {
 			return fmt.Errorf("%d status Code and %s regex didn't match in %s", resp.StatusCode, pattern.String(), name)

--- a/waitfor.go
+++ b/waitfor.go
@@ -158,7 +158,7 @@ func HTTPWaiter(name string, target *TargetConfig) error {
 	}
 	err = checkStatus(target.StatusPattern, resp.StatusCode)
 	if err != nil {
-		return fmt.Errorf("error in %s : %v", err, name)
+		return fmt.Errorf(" %v ", err)
 	}
 	return nil
 }
@@ -182,15 +182,13 @@ func GRPCWaiter(name string, target *TargetConfig) error {
 
 // checkStatus checks if the given HTTP status code matches the pattern provided in the target configuration.
 func checkStatus(targetPattern string, code int) error {
-	if targetPattern != "^2..$" {
-		// Safely compile and initialize  the regular expression pattern and verify if it's valid
-		pattern, err := regexp.Compile(targetPattern)
-		if err != nil {
-			return fmt.Errorf("invalid Regular Expression %v", err)
-		}
-		if !pattern.MatchString(strconv.Itoa(code)) {
-			return fmt.Errorf("%d status Code and %s regex didn't match", code, pattern.String())
-		}
+	// Safely compile and initialize  the regular expression pattern and verify if it's valid
+	pattern, err := regexp.Compile(targetPattern)
+	if err != nil {
+		return fmt.Errorf("invalid Regular Expression %v", err)
+	}
+	if !pattern.MatchString(strconv.Itoa(code)) {
+		return fmt.Errorf("%d status Code and %s regex didn't match ( -status=<RegexPattern> )", code, pattern.String())
 	}
 	return nil
 }

--- a/waitfor_test.go
+++ b/waitfor_test.go
@@ -25,7 +25,7 @@ var (
 )
 
 func TestStatusPattern200(t *testing.T) {
-	err := checkStatus("200", 200)
+	err := checkStatus("^2..$", 200)
 	assert.Nil(t, err)
 }
 
@@ -44,20 +44,10 @@ func TestRegexNotMatch(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func Test_isSuccess(t *testing.T) {
-	assert.True(t, isSuccess(200))
-	assert.True(t, isSuccess(214))
-	assert.False(t, isSuccess(300))
-	assert.False(t, isSuccess(199))
-	assert.False(t, isSuccess(100))
-	assert.False(t, isSuccess(500))
-	assert.False(t, isSuccess(407))
-}
-
 func TestOpenConfig_errorOnFileOpenFailure(t *testing.T) {
 	mockFS := afero.NewMemMapFs()
 
-	config, err := OpenConfig("./wait-for.yaml", "", "", afero.NewReadOnlyFs(mockFS), "")
+	config, err := OpenConfig("./wait-for.yaml", "", "", "", afero.NewReadOnlyFs(mockFS))
 	assert.Error(t, err)
 	assert.Nil(t, config)
 }
@@ -66,7 +56,7 @@ func TestOpenConfig_errorOnFileParsingFailure(t *testing.T) {
 	mockFS := afero.NewMemMapFs()
 	_ = afero.WriteFile(mockFS, "./wait-for.yaml", []byte("this isn't yaml!"), 0444)
 
-	config, err := OpenConfig("./wait-for.yaml", "", "", afero.NewReadOnlyFs(mockFS), "")
+	config, err := OpenConfig("./wait-for.yaml", "", "", "", afero.NewReadOnlyFs(mockFS))
 	assert.Error(t, err)
 	assert.Nil(t, config)
 }
@@ -75,7 +65,7 @@ func TestOpenConfig_errorOnParsingDefaultTimeout(t *testing.T) {
 	mockFS := afero.NewMemMapFs()
 	_ = afero.WriteFile(mockFS, "./wait-for.yaml", []byte(defaultConfigYaml()), 0444)
 
-	config, err := OpenConfig("./wait-for.yaml", "invalid duration", "1s", afero.NewReadOnlyFs(mockFS), "")
+	config, err := OpenConfig("./wait-for.yaml", "invalid duration", "1s", "", afero.NewReadOnlyFs(mockFS))
 	assert.Error(t, err)
 	assert.Nil(t, config)
 }
@@ -84,7 +74,7 @@ func TestOpenConfig_errorOnParsingDefaultHTTPTimeout(t *testing.T) {
 	mockFS := afero.NewMemMapFs()
 	_ = afero.WriteFile(mockFS, "./wait-for.yaml", []byte(defaultConfigYaml()), 0444)
 
-	config, err := OpenConfig("./wait-for.yaml", "10s", "invalid duration", afero.NewReadOnlyFs(mockFS), "")
+	config, err := OpenConfig("./wait-for.yaml", "10s", "invalid duration", "", afero.NewReadOnlyFs(mockFS))
 	assert.Error(t, err)
 	assert.Nil(t, config)
 }
@@ -93,7 +83,7 @@ func TestOpenConfig_defaultTimeoutCanBeSet(t *testing.T) {
 	mockFS := afero.NewMemMapFs()
 	_ = afero.WriteFile(mockFS, "./wait-for.yaml", []byte(defaultConfigYaml()), 0444)
 
-	config, err := OpenConfig("./wait-for.yaml", "19s", "1s", afero.NewReadOnlyFs(mockFS), "")
+	config, err := OpenConfig("./wait-for.yaml", "19s", "1s", "", afero.NewReadOnlyFs(mockFS))
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
 	assert.Equal(t, time.Second*19, config.DefaultTimeout)
@@ -103,7 +93,7 @@ func TestOpenConfig_defaultHTTPTimeoutCanBeSet(t *testing.T) {
 	mockFS := afero.NewMemMapFs()
 	_ = afero.WriteFile(mockFS, "./wait-for.yaml", []byte(defaultConfigYaml()), 0444)
 
-	config, err := OpenConfig("./wait-for.yaml", "19s", "20s", afero.NewReadOnlyFs(mockFS), "")
+	config, err := OpenConfig("./wait-for.yaml", "19s", "20s", "", afero.NewReadOnlyFs(mockFS))
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
 	assert.Equal(t, time.Second*20, config.DefaultHTTPClientTimeout)
@@ -113,7 +103,7 @@ func TestOpenConfig_defaultRegexCanBeSet(t *testing.T) {
 	mockFS := afero.NewMemMapFs()
 	_ = afero.WriteFile(mockFS, "./wait-for.yaml", []byte(defaultConfigYaml()), 0444)
 
-	config, err := OpenConfig("./wait-for.yaml", "5s", "5s", afero.NewReadOnlyFs(mockFS), "[0-9]+")
+	config, err := OpenConfig("./wait-for.yaml", "5s", "5s", "[0-9]+", afero.NewReadOnlyFs(mockFS))
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
 }

--- a/waitfor_test.go
+++ b/waitfor_test.go
@@ -88,6 +88,7 @@ func TestOpenConfig_defaultHTTPTimeoutCanBeSet(t *testing.T) {
 	assert.NotNil(t, config)
 	assert.Equal(t, time.Second*20, config.DefaultHTTPClientTimeout)
 }
+
 func TestOpenConfig_defaultRegexCanBeSet(t *testing.T) {
 	mockFS := afero.NewMemMapFs()
 	_ = afero.WriteFile(mockFS, "./wait-for.yaml", []byte(defaultConfigYaml()), 0444)
@@ -145,6 +146,7 @@ func TestWaitOnSingleTarget_succeedsAfterWaiting(t *testing.T) {
 	assert.Contains(t, logs, "error while waiting for name: there was an error")
 	assert.Contains(t, logs, "finished waiting for name")
 }
+
 func TestWaitOnSingleTarget_failsIfRegexInvalid(t *testing.T) {
 	var logs []string
 	doLog := func(f string, p ...interface{}) { logs = append(logs, fmt.Sprintf(f, p...)) }
@@ -152,7 +154,7 @@ func TestWaitOnSingleTarget_failsIfRegexInvalid(t *testing.T) {
 	err := waitOnSingleTarget(
 		"name",
 		doLog,
-		TargetConfig{RegexStatus: "{5-2}"},
+		TargetConfig{StatusPattern: "{5-2}"},
 		WaiterFunc(func(name string, target *TargetConfig) error {
 			return fmt.Errorf("")
 		}),

--- a/waitfor_test.go
+++ b/waitfor_test.go
@@ -24,6 +24,26 @@ var (
 	ip6 = net.IPv4(byte(0x24), byte(0x22), byte(0x23), byte(0x24))
 )
 
+func TestStatusPattern200(t *testing.T) {
+	err := checkStatus("200", 200)
+	assert.Nil(t, err)
+}
+
+func TestInvalidRegex(t *testing.T) {
+	err := checkStatus("[", 200)
+	assert.Error(t, err)
+}
+
+func TestRegexMatch(t *testing.T) {
+	err := checkStatus("2[0-9]{2}", 200)
+	assert.Nil(t, err)
+}
+
+func TestRegexNotMatch(t *testing.T) {
+	err := checkStatus("2[0-9]{2}", 404)
+	assert.Error(t, err)
+}
+
 func Test_isSuccess(t *testing.T) {
 	assert.True(t, isSuccess(200))
 	assert.True(t, isSuccess(214))


### PR DESCRIPTION
# Description

Adds an **optional** regex argument `-regex=<pattern>` for response codes instead of checking success codes only.
if no value is assigned to -regex , wait-for checks success codes as usual. 

Fixes #9

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I've integrated the defaultRegex so it won't break in all test cases and Added 2 new test cases: 
- defaultRegexCanBeSet : Checks if regex argument can be set
-failsIfRegexInvalid: Checks if command fail when provided with bad regular expressions. 

- [x] Running existing tests
- [x] Created new tests

# Checklist:

- [x] My code has been linted (`make lint`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes (`make test lint build acceptance-test`)
- [x] I have rebased my branch to include the latest changes from `master`
